### PR TITLE
Fix license link

### DIFF
--- a/docs/ECHOVAULT_OVERVIEW.md
+++ b/docs/ECHOVAULT_OVERVIEW.md
@@ -223,7 +223,7 @@ We appreciate all contributions\! Here’s how to get involved:
 
 ### 📑 License
 
-This project is licensed under the MIT License. See the [LICENSE](https://github.com/moarblur/project-horcrux/blob/main/LICENSE) file for full details. License subject to change in future iterations.
+This project is licensed under the MIT License. See the [LICENSE](../LICENSE) file for full details. License subject to change in future iterations.
 
 -----
 


### PR DESCRIPTION
## Summary
- reference local `LICENSE` in documentation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68437d627b4c8329b82b5723034dfbc5